### PR TITLE
Separate health listen address for easier kube-rbac-proxy protection

### DIFF
--- a/config/default/exporter_auth_proxy_patch.yaml
+++ b/config/default/exporter_auth_proxy_patch.yaml
@@ -9,8 +9,15 @@ spec:
     spec:
       containers:
       - name: exporter
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         args:
         - "--listen-addr=127.0.0.1:8080"
+        - "--health-listen-addr=$(POD_IP):8081"
       - name: kube-rbac-proxy
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/exporter/exporter.yaml
+++ b/config/exporter/exporter.yaml
@@ -57,7 +57,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8080
+            port: 8081
           periodSeconds: 20
           initialDelaySeconds: 15
           timeoutSeconds: 3


### PR DESCRIPTION
Adds new argument `health-listen-addr` for the health endpoint.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
