### PR TITLE
Replace `gcr.io` `kube-rbac-proxy` image

### DIFF
--- a/config/default/exporter_auth_proxy_patch.yaml
+++ b/config/default/exporter_auth_proxy_patch.yaml
@@ -24,7 +24,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.2
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
`gcr.io` is deprecated and will be removed https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
